### PR TITLE
capacity indicator adjusted in eventItems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geo-react-big-scheduler",
-  "version": "0.2.7-geo.8",
+  "version": "0.2.7-geo.9",
   "description": "A scheduler and resource planning component built for React and made for modern browsers (IE10+)",
   "keywords": [
     "scheduler",

--- a/src/EventItem.js
+++ b/src/EventItem.js
@@ -509,6 +509,13 @@ class EventItem extends Component {
         );
         if(eventItemTemplateResolver != undefined)
             eventItemTemplate = eventItemTemplateResolver(schedulerData, eventItem, bgColor, isStart, isEnd, 'event-item', config.eventItemHeight, undefined);
+        const h = config.eventItemHeight
+        const h2 = h+1;
+        if(top == h2){
+            top = config.indicatorHeight;
+        } else if(top > h2) {
+            top = top - ( h- config.indicatorHeight);
+        }
 
         let a = <a className="timeline-event" style={{left: left, width: width, top: top}} onClick={(e) => { if(!!eventItemClick) eventItemClick(schedulerData, eventItem, { left: left, width: width, top: top }, e);}}>
             {eventItemTemplate}

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ export default {
     yearMaxEvents: 99,
     customMaxEvents: 99,
 
+    indicatorHeight: 5,
     eventItemHeight: 22,
     eventItemLineHeight: 24,
     nonAgendaSlotMinHeight: 0,


### PR DESCRIPTION
getSummary also takes the same height as other eventItems so top value is decreased for the first event 